### PR TITLE
<<hover>> now accepts use of <<capture>>

### DIFF
--- a/hover-macro/hover-macro.js
+++ b/hover-macro/hover-macro.js
@@ -110,11 +110,12 @@ Macro.add('hover', {
           	callbacks.out.push(hideTip); 
         }
 
-      	$wrap.on('mouseenter focus', e => {
-          	if (active) return;
-          	active = true;
-          	callbacks.in.forEach(f => f.call());
-        }).on('mouseleave focusout', e => {
+      	$wrap.on('mouseenter focus', this.shadowHandler(
+                e => {
+                  if (active) return;
+                  active = true;
+                  callbacks.in.forEach(f => f.call());
+        })).on('mouseleave focusout', e => {
           	active = false;
         	callbacks.out.forEach(f => f.call());
         }).wiki(inner).addClass(`macro-${this.name}`).appendTo($(this.output));


### PR DESCRIPTION
NOTE: No minification file included.

Consider this SugarCube code:
```
:: od-odds [widget]
<<widget "od">>
    <<hover>>
        <underline><<= _args[0]>>od<<= _args[1]>></underline>
    <<tip>>
          <<capture _args[0], _args[1]>>
              <<= setup.getstats(_args[0], _args[1])>>
              <canvas id='myChart'></canvas>
          <</capture>>
    <</hover>>
<</widget>>
```
Previously, `_args[0]`, and `_args[1]` would only work in the `<<hover>>` portion of the macro. Now it also works in the `<<tip>>` and `<<swap>>` portions.